### PR TITLE
Fix: Prevent problem suggestions that were solved by specified handles

### DIFF
--- a/main.js
+++ b/main.js
@@ -385,14 +385,15 @@ async function get_problems() {
 
   let problems_out_of_scope = new Set();
 
-  not_solved_by.forEach(async (handle) => {
+  for (let handle of not_solved_by) {
     let url = `https://codeforces.com/api/user.status?handle=${handle}`;
     let submissions = await http_request(url);
     submissions["result"].forEach((submission) => {
-      if (submission["verdict"] === "OK")
+      if (submission["verdict"] === "OK") {
         problems_out_of_scope.add(submission["problem"]["name"]);
+      }
     });
-  });
+  }
 
   let chosen_tags = new Set();
 


### PR DESCRIPTION
Fixes #5

- Updated logic to correctly exclude problems solved by specified handles from the generated list of problems.
- Ensured that the problem generator no longer suggests problems that have been solved by the handles listed in `not_solved_by`, addressing inconsistencies caused by asynchronous handling.

Problem:
The issue occurred due to the use of `.forEach()` with asynchronous logic. In the previous implementation:
```js
not_solved_by.forEach(async (handle) => { // this was problematic
  let url = `https://codeforces.com/api/user.status?handle=${handle}`;
  let submissions = await http_request(url);
  submissions["result"].forEach((submission) => {
    if (submission["verdict"] === "OK")
      problems_out_of_scope.add(submission["problem"]["name"]);
  });
});
```
Since `.forEach()` doesn't handle asynchronous operations properly, the `problems_out_of_scope` set was not fully populated when it was later used to validate problems in:
```js
problemset["result"]["problems"].forEach((problem) => {
  if (valid_problem(problem, min, max, problems_out_of_scope, chosen_tags))
    available_problems.push(problem);
});
```

Solution:
Replaced `.forEach()` with a `for...of loop`, which correctly handles asynchronous code by allowing await to ensure all submissions are processed before moving on:

```js
for (let handle of not_solved_by) {
  let url = `https://codeforces.com/api/user.status?handle=${handle}`;
  let submissions = await http_request(url);
  submissions["result"].forEach((submission) => {
    if (submission["verdict"] === "OK") {
      problems_out_of_scope.add(submission["problem"]["name"]);
    }
  });
}
```
This ensures that `problems_out_of_scope` is fully populated before it is used in subsequent logic, fixing the inconsistency.
